### PR TITLE
Upgrade ZK, Curator, Netty, Jetty & Async HTTP client dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,25 +78,27 @@ For more details, please see https://issues.apache.org/jira/browse/AURORA-1169
   }
 
   ext.commonsLangRev = '3.12.0'
-  ext.curatorRev = '4.3.0'
+  ext.curatorRev = '5.1.0'
   ext.gsonRev = '2.3.1'
   ext.guavaRev = '29.0-jre'
   ext.guiceRev = '4.2.3'
   ext.httpclientRev = '4.5.13'
   ext.httpcoreRev = '4.4.14'
-  ext.asyncHttpclientRev = '2.0.37'
+  ext.asyncHttpclientRev = '2.10.5'
   ext.jacksonRev = '2.12.4'
   ext.jaxRsRev = '2.0'
   ext.junitRev = '4.13.2'
   ext.logbackRev = '1.2.3'
-  ext.nettyRev = '4.0.52.Final'
+  ext.nettyRev = '4.1.50.Final'
   ext.protobufRev = '3.17.3'
   ext.resteasyRev = '3.1.4.Final'
   ext.servletRev = '3.1.0'
   ext.slf4jRev = '1.7.31'
   ext.stringTemplateRev = '3.2.1'
   ext.thriftRev = '0.10.0'
-  ext.zookeeperRev = '3.4.8'
+  ext.zookeeperRev = '3.6.2'
+  ext.metricscoreRev = '3.2.5'
+  ext.snappyjavaRev = '1.1.7'
 
   configurations.all {
     exclude module: 'junit-dep'
@@ -120,6 +122,12 @@ For more details, please see https://issues.apache.org/jira/browse/AURORA-1169
       force "com.google.guava:guava:${guavaRev}"
       force "com.google.protobuf:protobuf-java:${protobufRev}"
       force "io.netty:netty-handler:${nettyRev}"
+      force "io.netty:netty-transport-native-epoll:${nettyRev}"
+      force "io.netty:netty-buffer:${nettyRev}"
+      force "io.netty:netty-codec:${nettyRev}"
+      force "io.netty:netty-common:${nettyRev}"
+      force "io.netty:netty-transport:${nettyRev}"
+      force "io.netty:netty-transport-native-unix-common:${nettyRev}"
       force "junit:junit:${junitRev}"
       force "org.apache.thrift:libthrift:${thriftRev}"
       force "org.apache.zookeeper:zookeeper:${zookeeperRev}"
@@ -198,6 +206,8 @@ project(':commons') {
     compile "javax.ws.rs:javax.ws.rs-api:${jaxRsRev}"
     compile "org.antlr:stringtemplate:${stringTemplateRev}"
     compile "org.apache.zookeeper:zookeeper:${zookeeperRev}"
+    compile "io.dropwizard.metrics:metrics-core:${metricscoreRev}"
+    compile "org.xerial.snappy:snappy-java:${snappyjavaRev}"
     compile "org.easymock:easymock:3.4"
 
     // There are a few testing support libs in the src/main/java trees that use junit - currently:
@@ -367,7 +377,7 @@ sourceSets {
 
 dependencies {
   def shiroRev = '1.7.1'
-  def jettyDep = '9.3.11.v20160721'
+  def jettyDep = '9.4.24.v20191120'
 
   compile project(':api')
   compile project(':commons')

--- a/commons/src/main/java/org/apache/aurora/common/zookeeper/testing/ZooKeeperTestServer.java
+++ b/commons/src/main/java/org/apache/aurora/common/zookeeper/testing/ZooKeeperTestServer.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.apache.zookeeper.server.ZooKeeperServer.BasicDataTreeBuilder;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 
 /**
@@ -49,9 +48,7 @@ public class ZooKeeperTestServer {
    */
   public void startNetwork() throws IOException, InterruptedException {
     zooKeeperServer =
-        new ZooKeeperServer(
-            new FileTxnSnapLog(dataDir, snapDir),
-            new BasicDataTreeBuilder()) {
+        new ZooKeeperServer(new FileTxnSnapLog(dataDir, snapDir)) {
 
           // TODO(John Sirois): Introduce a builder to configure the in-process server if and when
           // some folks need JMX for in-process tests.

--- a/src/main/java/org/apache/aurora/scheduler/discovery/CuratorServiceDiscoveryModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/discovery/CuratorServiceDiscoveryModule.java
@@ -41,7 +41,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.listen.Listenable;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.BoundedExponentialBackoffRetry;
@@ -212,8 +212,7 @@ class CuratorServiceDiscoveryModule extends PrivateModule {
       ShutdownRegistry shutdownRegistry,
       CuratorFramework client) {
 
-    PathChildrenCache groupCache =
-        new PathChildrenCache(client, discoveryPath, true /* cacheData */);
+    CuratorCache groupCache = CuratorCache.builder(client, discoveryPath).build();
 
     // NB: Even though we do not start the serviceGroupMonitor here, the registered close shutdown
     // action is safe since the underlying PathChildrenCache close is tolerant of an un-started

--- a/src/main/java/org/apache/aurora/scheduler/http/JettyServerModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/JettyServerModule.java
@@ -73,10 +73,11 @@ import org.apache.aurora.scheduler.thrift.ThriftModule;
 import org.apache.aurora.scheduler.thrift.aop.AopModule;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.rewrite.handler.RewriteRegexRule;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
@@ -386,7 +387,8 @@ public class JettyServerModule extends AbstractModule {
       HandlerCollection rootHandler = new HandlerList();
 
       RequestLogHandler logHandler = new RequestLogHandler();
-      logHandler.setRequestLog(new Slf4jRequestLog());
+      logHandler.setRequestLog(new CustomRequestLog(new Slf4jRequestLogWriter(),
+              CustomRequestLog.EXTENDED_NCSA_FORMAT));
 
       rootHandler.addHandler(logHandler);
       rootHandler.addHandler(servletHandler);

--- a/src/test/java/org/apache/aurora/scheduler/discovery/BaseCuratorDiscoveryTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/discovery/BaseCuratorDiscoveryTest.java
@@ -24,7 +24,8 @@ import org.apache.aurora.scheduler.app.ServiceGroupMonitor;
 import org.apache.aurora.scheduler.discovery.ServiceInstance.Endpoint;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.junit.Before;
 
@@ -41,19 +42,17 @@ class BaseCuratorDiscoveryTest extends BaseZooKeeperTest {
   @Before
   public void setUpCurator() {
     client = startNewClient();
-
-    PathChildrenCache groupCache =
-        new PathChildrenCache(client, GROUP_PATH, true /* cacheData */);
+    CuratorCache groupCache = CuratorCache.builder(client, GROUP_PATH).build();
     groupEvents = new LinkedBlockingQueue<>();
-    groupCache.getListenable().addListener((c, event) -> groupEvents.put(event));
-
+    CuratorCacheListener listener = CuratorCacheListener.builder()
+            .forPathChildrenCache(GROUP_PATH, client, (c, event) -> groupEvents.put(event)).build();
+    groupCache.listenable().addListener(listener);
     Predicate<String> memberSelector = name -> name.contains(MEMBER_TOKEN);
     groupMonitor = new CuratorServiceGroupMonitor(groupCache, memberSelector);
   }
 
   final CuratorFramework startNewClient() {
     CuratorFramework curator = CuratorFrameworkFactory.builder()
-        .dontUseContainerParents() // Container nodes are only available in ZK 3.5+.
         .retryPolicy((retryCount, elapsedTimeMs, sleeper) -> false) // Don't retry.
         .connectString(String.format("localhost:%d", getServer().getPort()))
         .build();

--- a/src/test/java/org/apache/aurora/scheduler/discovery/CuratorServiceGroupMonitorTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/discovery/CuratorServiceGroupMonitorTest.java
@@ -116,8 +116,8 @@ public class CuratorServiceGroupMonitorTest extends BaseCuratorDiscoveryTest {
 
     // Not started yet, should see no group members.
     assertEquals(ImmutableSet.of(), getGroupMonitor().get());
-
     startGroupMonitor();
+    Thread.sleep(1000); // Sleep to populate initial cache
     assertEquals(ImmutableSet.of(one, two), getGroupMonitor().get());
   }
 

--- a/src/test/java/org/apache/aurora/scheduler/events/WebhookTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/events/WebhookTest.java
@@ -38,7 +38,6 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.HttpResponseBodyPart;
-import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
@@ -48,6 +47,8 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import io.netty.handler.codec.http.HttpHeaders;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -135,7 +136,7 @@ public class WebhookTest {
     }
 
     @Override
-    public State onHeadersReceived(HttpResponseHeaders headers) throws Exception {
+    public State onHeadersReceived(HttpHeaders headers) throws Exception {
       return handler.onHeadersReceived(headers);
     }
 


### PR DESCRIPTION
### Description:
This PR upgrades ZK dependency from 3.4.8 to 3.6.2 and Curator dependency from 4.3.0 to 5.1.0.
Netty is upgraded as needed by ZK. metrics-core and snappy-java are provided compiles for newer ZK and hence they are added to the Gradle file.

Async HTTP client was also upgraded as it depended on the older version of Jetty, of which newer version is needed by upgraded ZK.


### Testing Done:
Ran UTs and e2e tests.