### PR TITLE
Improve HttpOfferSet performance

### DIFF
--- a/docs/features/custom-plugins.md
+++ b/docs/features/custom-plugins.md
@@ -58,3 +58,13 @@ The server returns the response in the following format.
 }
 ```
 In the above example, the external REST API sorts the offers based on the number of available vcpus.
+
+How to monitor HTTP OfferSet?
+We can monitor this plugin by looking at the endpoint `/vars`. The following metrics are available when HTTP OfferSet is enabled:
+- `http_offer_set_avg_latency_ms`: The average latency per scheduling cycle in milliseconds.
+- `http_offer_set_median_latency_ms`: The median latency per scheduling cycle in milliseconds.
+- `http_offer_set_worst_latency_ms`: The worst latency per scheduling cycle in milliseconds.
+- `http_offer_set_failure_count`: The number of scheduling failures.
+- `http_offer_set_max_diff`: The number of different offers between the original `OfferSet` and the received one.
+
+HTTP OfferSet resets the above metrics every `sla_stat_refresh_interval`.

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
@@ -209,7 +209,7 @@ public class HttpOfferSetImpl implements OfferSet {
     request.setConfig(requestConfig);
     request.addHeader("Content-Type", "application/json; utf-8");
     request.addHeader("Accept", "application/json");
-    request.setEntity(new StringEntity(new ObjectMapper().writeValueAsString(scheduleRequest)));
+    request.setEntity(new StringEntity(jsonMapper.writeValueAsString(scheduleRequest)));
     CloseableHttpResponse response = httpClient.execute(request);
     try {
       HttpEntity entity = response.getEntity();

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
@@ -67,8 +67,8 @@ public class HttpOfferSetImpl implements OfferSet {
   private static final Logger LOG = LoggerFactory.getLogger(HttpOfferSetImpl.class);
   private final Set<HostOffer> offers;
   private final ObjectMapper jsonMapper = new ObjectMapper();
-  // we can reuse CloseableHttpClient for multiple requests
-  private static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();
+  // Using CloseableHttpClient for multiple requests
+  private final CloseableHttpClient httpClient = HttpClients.createDefault();
 
   private Integer timeoutMs;
   private URL endpoint;
@@ -214,7 +214,7 @@ public class HttpOfferSetImpl implements OfferSet {
     request.addHeader("Content-Type", "application/json; utf-8");
     request.addHeader("Accept", "application/json");
     request.setEntity(new StringEntity(jsonMapper.writeValueAsString(scheduleRequest)));
-    CloseableHttpResponse response = HTTP_CLIENT.execute(request);
+    CloseableHttpResponse response = httpClient.execute(request);
     try {
       HttpEntity entity = response.getEntity();
       if (entity == null) {

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
@@ -74,8 +74,8 @@ public class HttpOfferSetImpl implements OfferSet {
   private URL endpoint;
   private Integer maxRetries;
 
-  public HttpOfferSetImpl(Set<HostOffer> offers) {
-    this.offers = offers;
+  public HttpOfferSetImpl(Set<HostOffer> mOffers) {
+    offers = mOffers;
   }
 
   @VisibleForTesting
@@ -95,9 +95,9 @@ public class HttpOfferSetImpl implements OfferSet {
 
   @Inject
   public HttpOfferSetImpl(Ordering<HostOffer> ordering,
-                          @TimeoutMs Integer timeoutMs,
+                          @TimeoutMs Integer mTimeoutMs,
                           @Endpoint String url,
-                          @MaxRetries Integer maxRetries) {
+                          @MaxRetries Integer mMaxRetries) {
     offers = new ConcurrentSkipListSet<>(ordering);
     try {
       endpoint = new URL(url);
@@ -108,11 +108,11 @@ public class HttpOfferSetImpl implements OfferSet {
       HttpOfferSetModule.enable(false);
       LOG.info("HttpOfferSetModule Disabled.");
     }
-    this.timeoutMs = timeoutMs;
-    this.maxRetries = maxRetries;
-    LOG.info("HttpOfferSet's endpoint: " + this.endpoint);
-    LOG.info("HttpOfferSet's timeout: " + this.timeoutMs + " (ms)");
-    LOG.info("HttpOfferSet's max retries: " + this.maxRetries);
+    timeoutMs = mTimeoutMs;
+    maxRetries = mMaxRetries;
+    LOG.info("HttpOfferSet's endpoint: " + endpoint);
+    LOG.info("HttpOfferSet's timeout: " + timeoutMs + " (ms)");
+    LOG.info("HttpOfferSet's max retries: " + maxRetries);
   }
 
   @Override
@@ -153,9 +153,9 @@ public class HttpOfferSetImpl implements OfferSet {
     try {
       long startTime = System.nanoTime();
       // create json request & send the Rest API request to the scheduler plugin
-      ScheduleRequest scheduleRequest = this.createRequest(resourceRequest, startTime);
+      ScheduleRequest scheduleRequest = createRequest(resourceRequest, startTime);
       LOG.info("Sending request " + scheduleRequest.jobKey);
-      String responseStr = this.sendRequest(scheduleRequest);
+      String responseStr = sendRequest(scheduleRequest);
       orderedOffers = processResponse(responseStr, HttpOfferSetModule.offerSetDiffList);
       HttpOfferSetModule.latencyMsList.add(System.nanoTime() - startTime);
     } catch (IOException e) {
@@ -381,7 +381,7 @@ public class HttpOfferSetImpl implements OfferSet {
     }
 
     public void setRequest(Resource mRequest) {
-      this.request = mRequest;
+      request = mRequest;
     }
 
     public List<Host> getHosts() {
@@ -389,7 +389,7 @@ public class HttpOfferSetImpl implements OfferSet {
     }
 
     public void setHosts(List<Host> mHosts) {
-      this.hosts = mHosts;
+      hosts = mHosts;
     }
   }
 
@@ -409,16 +409,16 @@ public class HttpOfferSetImpl implements OfferSet {
       return error;
     }
 
-    public void setError(String error) {
-      this.error = error;
+    public void setError(String mError) {
+      error = mError;
     }
 
     public List<String> getHosts() {
       return hosts;
     }
 
-    public void setHosts(List<String> hosts) {
-      this.hosts = hosts;
+    public void setHosts(List<String> mHosts) {
+      hosts = mHosts;
     }
   }
 }

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
@@ -246,15 +246,16 @@ public class HttpOfferSetImpl implements OfferSet {
     if (offSetDiff > 0) {
       LOG.warn("The number of different offers between the original and received offer sets is "
           + offSetDiff);
-    }
-    if (LOG.isDebugEnabled() && offSetDiff > 0) {
-      List<String> missedOffers = offers.stream()
+      if (LOG.isDebugEnabled()) {
+        List<String> missedOffers = offers.stream()
             .map(offer -> offer.getAttributes().getHost())
             .filter(host -> !response.hosts.contains(host))
             .collect(Collectors.toList());
-      LOG.debug("missed offers: " + missedOffers);
-      LOG.debug("extra offers: " + extraOffers);
+        LOG.debug("missed offers: " + missedOffers);
+        LOG.debug("extra offers: " + extraOffers);
+      }
     }
+
     if (!extraOffers.isEmpty()) {
       LOG.error("Cannot find offers " + extraOffers + " in the original offer set");
     }

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
@@ -56,6 +56,7 @@ public class HttpOfferSetModule extends AbstractModule {
   private final Options options;
   private static final Logger LOG = LoggerFactory.getLogger(HttpOfferSetModule.class);
   static List<Long> latencyMsList = Collections.synchronizedList(new LinkedList<>());
+  static List<Long> offerSetDiff = Collections.synchronizedList(new LinkedList<>());
   private static long failureCount = 0;
   private static boolean enabled = false;
 

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
@@ -56,7 +56,7 @@ public class HttpOfferSetModule extends AbstractModule {
   private final Options options;
   private static final Logger LOG = LoggerFactory.getLogger(HttpOfferSetModule.class);
   static List<Long> latencyMsList = Collections.synchronizedList(new LinkedList<>());
-  static List<Long> offerSetDiff = Collections.synchronizedList(new LinkedList<>());
+  static List<Long> offerSetDiffList = Collections.synchronizedList(new LinkedList<>());
   private static long failureCount = 0;
   private static boolean enabled = false;
 

--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetModule.java
@@ -97,9 +97,9 @@ public class HttpOfferSetModule extends AbstractModule {
     CommandLine.registerCustomOptions(new Options());
   }
 
-  public HttpOfferSetModule(CliOptions options) {
-    this.cliOptions = options;
-    this.options = options.getCustom(Options.class);
+  public HttpOfferSetModule(CliOptions mOptions) {
+    cliOptions = mOptions;
+    options = mOptions.getCustom(Options.class);
   }
 
   @Override
@@ -152,18 +152,17 @@ public class HttpOfferSetModule extends AbstractModule {
 
     @Inject
     StatUpdater(
-            @Executor ScheduledExecutorService executor,
-            StatCalculator calculator,
-            @RefreshRateMs Integer refreshRateMs) {
-      this.executor = requireNonNull(executor);
-      this.calculator = requireNonNull(calculator);
-      this.refreshRateMs = refreshRateMs;
+            @Executor ScheduledExecutorService mExecutor,
+            StatCalculator mCalculator,
+            @RefreshRateMs Integer mRefreshRateMs) {
+      executor = requireNonNull(mExecutor);
+      calculator = requireNonNull(mCalculator);
+      refreshRateMs = mRefreshRateMs;
     }
 
     @Override
     protected void startUp() {
-      long interval = this.refreshRateMs;
-      executor.scheduleAtFixedRate(calculator, 0, interval, TimeUnit.MILLISECONDS);
+      executor.scheduleAtFixedRate(calculator, 0, refreshRateMs, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
@@ -34,8 +34,8 @@ public class StatCalculator implements Runnable {
     private final StatsProvider statsProvider;
     private boolean exported;
 
-    Counter(StatsProvider statsProvider) {
-      this.statsProvider = statsProvider;
+    Counter(StatsProvider mStatsProvider) {
+      statsProvider = mStatsProvider;
     }
 
     @Override
@@ -55,7 +55,7 @@ public class StatCalculator implements Runnable {
   @Inject
   StatCalculator(final StatsProvider statsProvider) {
     requireNonNull(statsProvider);
-    this.metricCache = CacheBuilder.newBuilder().build(
+    metricCache = CacheBuilder.newBuilder().build(
         new CacheLoader<String, StatCalculator.Counter>() {
           public StatCalculator.Counter load(String key) {
             return new StatCalculator.Counter(statsProvider.untracked());

--- a/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
@@ -83,7 +83,7 @@ public class StatCalculator implements Runnable {
     metricCache.getUnchecked(failureCountName).set(failureCountName,
             HttpOfferSetModule.getFailureCount());
 
-    long maxOfferSetDiff = Util.max(HttpOfferSetModule.offerSetDiff);
+    long maxOfferSetDiff = Util.max(HttpOfferSetModule.offerSetDiffList);
     String maxOffSetDiffName = "http_offer_set_max_diff";
     metricCache.getUnchecked(maxOffSetDiffName).set(maxOffSetDiffName,
         maxOfferSetDiff);
@@ -91,6 +91,6 @@ public class StatCalculator implements Runnable {
     // reset the stats.
     HttpOfferSetModule.latencyMsList.clear();
     HttpOfferSetModule.resetFailureCount();
-    HttpOfferSetModule.offerSetDiff.clear();
+    HttpOfferSetModule.offerSetDiffList.clear();
   }
 }

--- a/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
@@ -91,6 +91,6 @@ public class StatCalculator implements Runnable {
     // reset the stats.
     HttpOfferSetModule.latencyMsList.clear();
     HttpOfferSetModule.resetFailureCount();
-//    HttpOfferSetModule.offerSetDiff.clear();
+    HttpOfferSetModule.offerSetDiff.clear();
   }
 }

--- a/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/StatCalculator.java
@@ -83,8 +83,14 @@ public class StatCalculator implements Runnable {
     metricCache.getUnchecked(failureCountName).set(failureCountName,
             HttpOfferSetModule.getFailureCount());
 
+    long maxOfferSetDiff = Util.max(HttpOfferSetModule.offerSetDiff);
+    String maxOffSetDiffName = "http_offer_set_max_diff";
+    metricCache.getUnchecked(maxOffSetDiffName).set(maxOffSetDiffName,
+        maxOfferSetDiff);
+
     // reset the stats.
     HttpOfferSetModule.latencyMsList.clear();
     HttpOfferSetModule.resetFailureCount();
+//    HttpOfferSetModule.offerSetDiff.clear();
   }
 }

--- a/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
+++ b/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
@@ -15,6 +15,7 @@ package io.github.aurora.scheduler.offers;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.aurora.common.testing.easymock.EasyMockTest;
@@ -66,20 +67,24 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_A + "\",\""
             + HOST_B + "\",\""
             + HOST_C + "\"]}";
-    List<HostOffer> sortedOffers = httpOfferSet.processResponse(responseStr);
+    List<Long> offerSetDiffList = new LinkedList<>();
+
+    List<HostOffer> sortedOffers = httpOfferSet.processResponse(responseStr, offerSetDiffList);
     assertEquals(sortedOffers.size(), 3);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
     assertEquals(sortedOffers.get(2).getAttributes().getHost(), HOST_C);
+    assertEquals((long) offerSetDiffList.get(0), 0);
 
     // plugin returns less offers than Aurora has.
     responseStr = "{\"error\": \"\", \"hosts\": [\""
             + HOST_A + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = httpOfferSet.processResponse(responseStr);
+    sortedOffers = httpOfferSet.processResponse(responseStr, offerSetDiffList);
     assertEquals(sortedOffers.size(), 2);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
+    assertEquals((long) offerSetDiffList.get(1), 1);
 
     // plugin returns more offers than Aurora has.
     responseStr = "{\"error\": \"\", \"hosts\": [\""
@@ -87,11 +92,23 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_B + "\",\""
             + HOST_D + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = httpOfferSet.processResponse(responseStr);
+    sortedOffers = httpOfferSet.processResponse(responseStr, offerSetDiffList);
     assertEquals(sortedOffers.size(), 3);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
     assertEquals(sortedOffers.get(2).getAttributes().getHost(), HOST_C);
+    assertEquals((long) offerSetDiffList.get(2), 1);
+
+    // plugin omits 1 offer & returns 1 extra offer
+    responseStr = "{\"error\": \"\", \"hosts\": [\""
+        + HOST_A + "\",\""
+        + HOST_D + "\",\""
+        + HOST_C + "\"]}";
+    sortedOffers = httpOfferSet.processResponse(responseStr, offerSetDiffList);
+    assertEquals(sortedOffers.size(), 2);
+    assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
+    assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
+    assertEquals((long) offerSetDiffList.get(3), 2);
 
     responseStr = "{\"error\": \"Error\", \"hosts\": [\""
             + HOST_A + "\",\""
@@ -99,7 +116,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_C + "\"]}";
     boolean isException = false;
     try {
-      httpOfferSet.processResponse(responseStr);
+      httpOfferSet.processResponse(responseStr, offerSetDiffList);
     } catch (IOException ioe) {
       isException = true;
     }
@@ -108,7 +125,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     responseStr = "{\"error\": \"\"}";
     isException = false;
     try {
-      httpOfferSet.processResponse(responseStr);
+      httpOfferSet.processResponse(responseStr, new LinkedList<>());
     } catch (IOException ioe) {
       isException = true;
     }

--- a/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
+++ b/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
@@ -122,7 +122,16 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     }
     assertTrue(isException);
 
-    responseStr = "{\"error\": \"\"}";
+    responseStr = "{\"error\": \"error\"}";
+    isException = false;
+    try {
+      httpOfferSet.processResponse(responseStr, new LinkedList<>());
+    } catch (IOException ioe) {
+      isException = true;
+    }
+    assertTrue(isException);
+
+    responseStr = "{\"weird\": \"cannot decode this json string\"}";
     isException = false;
     try {
       httpOfferSet.processResponse(responseStr, new LinkedList<>());


### PR DESCRIPTION
### Description:
- Improve json encoding performance by replacing gson with jackson.
- Use ClosableHttpClient for multiple requests.
- Monitor the differences between the original offerset and the received ones.

### Testing Done:
- performance test on 2000 offers with ~3ms improvement per scheduling cycle.
- verify the correctness on 2-agent cluster setup.
