### PR TITLE
Disable pauses for auto pause enabled updates

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
@@ -262,7 +262,7 @@ class JobUpdateControllerImpl implements JobUpdateController {
             .getInstructions()
             .getSettings()
             .getUpdateStrategy());
-    if (isAutoPauseEnabled && instancesSeen.containsKey(key)) {
+    if (isAutoPauseEnabled) {
       throw new UpdateStateException("Pauses not allowed on auto-pause enabled job updates");
     }
     LOG.info("Attempting to pause update " + key);


### PR DESCRIPTION
Add IT

Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>

### Description:
This PR prevents pauses on auto pause enabled job updates.


### Testing Done:
Ran UTs - all passed
E2E tests (failures unrelated to this commit)