### PR TITLE
Revert "Disable pauses for auto pause enabled updates (#216)"

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
@@ -255,16 +255,6 @@ class JobUpdateControllerImpl implements JobUpdateController {
   @Override
   public void pause(final IJobUpdateKey key, AuditData auditData) throws UpdateStateException {
     requireNonNull(key);
-    Optional<IJobUpdateDetails> update = storage.read(p -> p.getJobUpdateStore()
-            .fetchJobUpdate(key));
-    Boolean isAutoPauseEnabled = update.isPresent() && isAutoPauseEnabled(update.get()
-            .getUpdate()
-            .getInstructions()
-            .getSettings()
-            .getUpdateStrategy());
-    if (isAutoPauseEnabled) {
-      throw new UpdateStateException("Pauses not allowed on auto-pause enabled job updates");
-    }
     LOG.info("Attempting to pause update " + key);
     unscopedChangeUpdateStatus(
         key,

--- a/src/test/java/org/apache/aurora/scheduler/updater/JobUpdaterIT.java
+++ b/src/test/java/org/apache/aurora/scheduler/updater/JobUpdaterIT.java
@@ -110,7 +110,6 @@ import org.apache.aurora.scheduler.updater.UpdaterModule.UpdateActionBatchWorker
 import org.easymock.EasyMock;
 import org.easymock.IExpectationSetters;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -2030,68 +2029,6 @@ public class JobUpdaterIT extends EasyMockTest {
             .put(0, OLD_CONFIG)
             .put(1, OLD_CONFIG)
             .build());
-  }
-
-  @Test
-  public void testPauseFailsWithAutoPauseEnabled() throws Exception {
-    expectTaskKilled().times(3);
-    control.replay();
-
-    JobUpdate builder = makeJobUpdate(makeInstanceConfig(0, 2, OLD_CONFIG)).newBuilder();
-    builder.getInstructions().getSettings()
-            .setUpdateStrategy(
-                    JobUpdateStrategy.varBatchStrategy(
-                            new VariableBatchJobUpdateStrategy()
-                                    .setGroupSizes(ImmutableList.of(1, 2))
-                                    .setAutopauseAfterBatch(true)));
-    IJobUpdate update = setInstanceCount(IJobUpdate.build(builder), 3);
-    insertInitialTasks(update);
-
-    for (int i = 0; i <= 2; ++i) {
-      changeState(JOB, i, ASSIGNED, STARTING, RUNNING);
-    }
-    clock.advance(WATCH_TIMEOUT);
-
-    ImmutableMultimap.Builder<Integer, JobUpdateAction> actions = ImmutableMultimap.builder();
-
-    // Update first batch
-    updater.start(update, AUDIT);
-    actions.put(0, INSTANCE_UPDATING);
-    assertState(ROLLING_FORWARD, actions.build());
-    // Pause should fail
-    Assert.assertThrows(UpdateStateException.class, () -> updater.pause(UPDATE_ID, AUDIT));
-    changeState(JOB, 0, FINISHED, ASSIGNED, STARTING, RUNNING);
-    clock.advance(WATCH_TIMEOUT);
-    actions.put(0, INSTANCE_UPDATED);
-
-    assertState(ROLL_FORWARD_PAUSED, actions.build());
-    // Pause should fail
-    Assert.assertThrows(UpdateStateException.class, () -> updater.pause(UPDATE_ID, AUDIT));
-    updater.resume(UPDATE_ID, AUDIT);
-
-    actions.put(1, INSTANCE_UPDATING).put(2, INSTANCE_UPDATING);
-    assertState(ROLLING_FORWARD, actions.build());
-    // Pause should fail
-    Assert.assertThrows(UpdateStateException.class, () -> updater.pause(UPDATE_ID, AUDIT));
-
-    // Update second batch
-    changeState(JOB, 1, FINISHED, ASSIGNED, STARTING, RUNNING);
-    changeState(JOB, 2, FINISHED, ASSIGNED, STARTING, RUNNING);
-    clock.advance(WATCH_TIMEOUT);
-
-    actions.put(1, INSTANCE_UPDATED);
-    actions.put(2, INSTANCE_UPDATED);
-
-    assertState(ROLLED_FORWARD, actions.build());
-    Assert.assertThrows(UpdateStateException.class, () -> updater.pause(UPDATE_ID, AUDIT));
-
-    assertJobState(
-            JOB,
-            ImmutableMap.<Integer, ITaskConfig>builder()
-                    .put(0, NEW_CONFIG)
-                    .put(1, NEW_CONFIG)
-                    .put(2, NEW_CONFIG)
-                    .build());
   }
 
   private Collection<IScheduledTask> getTasksInState(IJobKey job, ScheduleStatus status) {


### PR DESCRIPTION
This reverts commit c64f72f5ac77782fdf7410db653dfb3e084b3919.

### Description:
Code is robust to handle user pauses during auto pause enabled updates

### Testing Done:
Not required as this is a revert to earlier code