### PR TITLE
Upgrade ZK client version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ For more details, please see https://issues.apache.org/jira/browse/AURORA-1169
   ext.slf4jRev = '1.7.31'
   ext.stringTemplateRev = '3.2.1'
   ext.thriftRev = '0.10.0'
-  ext.zookeeperRev = '3.4.8'
+  ext.zookeeperRev = '3.4.14'
 
   configurations.all {
     exclude module: 'junit-dep'


### PR DESCRIPTION
Signed-off-by: Abdul Qadeer <quadeer.leo@gmail.com>

### Description:
This PR upgrades ZK client from 3.4.8 to latest in 3.4, 3.4.14.
Current curator version is new enough for ZK 3.4
Addresses https://github.com/aurora-scheduler/scheduler/issues/63


### Testing Done:
Ran UTs and e2e tests