### PR TITLE
Update Mesos library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -391,7 +391,7 @@ dependencies {
   compile "org.apache.curator:curator-client:${curatorRev}"
   compile "org.apache.curator:curator-framework:${curatorRev}"
   compile "org.apache.curator:curator-recipes:${curatorRev}"
-  compile 'org.apache.mesos:mesos:1.8.1'
+  compile 'org.apache.mesos:mesos:1.9.0'
   compile "org.asynchttpclient:async-http-client:${asyncHttpclientRev}"
   compile "org.apache.shiro:shiro-guice:${shiroRev}"
   compile "org.apache.shiro:shiro-web:${shiroRev}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         ipv4_address: 192.168.33.2
 
   master:
-    image: aurorascheduler/mesos-master:1.8.1
+    image: quay.io/aurorascheduler/mesos-master:1.9.0
     restart: on-failure
     ports:
     - "5050:5050"
@@ -32,7 +32,7 @@ services:
     - zk
 
   agent:
-    image: aurorascheduler/mesos-agent:1.8.1
+    image: quay.io/aurorascheduler/mesos-agent:1.9.0
     pid: host
     restart: on-failure
     ports:


### PR DESCRIPTION
Upgrade Docker dev env images

Signed-off-by: Abdul Qadeer <quadeer.leo@gmail.com>

### Description:

Addresses https://github.com/aurora-scheduler/scheduler/issues/47 partially. 


### Testing Done:
UT and Goreals e2e tests:

```realis: 2021/09/21 08:03:49 Scheduler URL:  http://192.168.33.7:8081
realis: 2021/09/21 08:03:49 gorealis clientConfig url: http://192.168.33.7:8081/api
=== RUN   TestGetCACerts
--- PASS: TestGetCACerts (0.02s)
=== RUN   TestAuroraURLValidator
=== RUN   TestAuroraURLValidator/badURL
=== RUN   TestAuroraURLValidator/URLHttp
=== RUN   TestAuroraURLValidator/URLHttps
=== RUN   TestAuroraURLValidator/URLNoPath
=== RUN   TestAuroraURLValidator/ipAddrNoPath
=== RUN   TestAuroraURLValidator/URLNoProtocol
=== RUN   TestAuroraURLValidator/URLNoProtocolNoPathNoPort
--- PASS: TestAuroraURLValidator (0.00s)
    --- PASS: TestAuroraURLValidator/badURL (0.00s)
    --- PASS: TestAuroraURLValidator/URLHttp (0.00s)
    --- PASS: TestAuroraURLValidator/URLHttps (0.00s)
    --- PASS: TestAuroraURLValidator/URLNoPath (0.00s)
    --- PASS: TestAuroraURLValidator/ipAddrNoPath (0.00s)
    --- PASS: TestAuroraURLValidator/URLNoProtocol (0.00s)
    --- PASS: TestAuroraURLValidator/URLNoProtocolNoPathNoPort (0.00s)
=== RUN   TestThermosTask
--- PASS: TestThermosTask (0.00s)
=== RUN   TestCurrentBatchCalculator
=== RUN   TestCurrentBatchCalculator/singleBatchOverflow
=== RUN   TestCurrentBatchCalculator/noInstancesUpdating
=== RUN   TestCurrentBatchCalculator/evenMatchSingleBatch
=== RUN   TestCurrentBatchCalculator/moreInstancesThanBatches
=== RUN   TestCurrentBatchCalculator/moreInstancesThanBatchesDecreasing
=== RUN   TestCurrentBatchCalculator/unevenFit
=== RUN   TestCurrentBatchCalculator/halfWay
--- PASS: TestCurrentBatchCalculator (0.00s)
    --- PASS: TestCurrentBatchCalculator/singleBatchOverflow (0.00s)
    --- PASS: TestCurrentBatchCalculator/noInstancesUpdating (0.00s)
    --- PASS: TestCurrentBatchCalculator/evenMatchSingleBatch (0.00s)
    --- PASS: TestCurrentBatchCalculator/moreInstancesThanBatches (0.00s)
    --- PASS: TestCurrentBatchCalculator/moreInstancesThanBatchesDecreasing (0.00s)
    --- PASS: TestCurrentBatchCalculator/unevenFit (0.00s)
    --- PASS: TestCurrentBatchCalculator/halfWay (0.00s)
=== RUN   TestLoadClusters
--- PASS: TestLoadClusters (0.00s)
=== RUN   TestNonExistentEndpoint
realis: 2021/09/21 08:03:49 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:49 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:49 Client Error: Post http://doesntexist.com:8081/api: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
realis: 2021/09/21 08:03:49 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:49 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:49 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:49 A retryable error occurred during thrift call, backing off for 1.046954717s before retry 1
realis: 2021/09/21 08:03:51 Client Error: Post http://doesntexist.com:8081/api: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
realis: 2021/09/21 08:03:51 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:51 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:51 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:51 A retryable error occurred during thrift call, backing off for 1.007808877s before retry 2
realis: 2021/09/21 08:03:52 Client Error: Post http://doesntexist.com:8081/api: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
realis: 2021/09/21 08:03:52 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:52 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:52 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:52 A retryable error occurred during thrift call, backing off for 1.06597801s before retry 3
realis: 2021/09/21 08:03:53 Client Error: Post http://doesntexist.com:8081/api: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
realis: 2021/09/21 08:03:53 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:53 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:53 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:53 A retryable error occurred during thrift call, backing off for 1.078977309s before retry 4
realis: 2021/09/21 08:03:54 Client Error: Post http://doesntexist.com:8081/api: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
realis: 2021/09/21 08:03:54 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:54 Scheduler URL:  http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:54 gorealis clientConfig url: http://doesntexist.com:8081/api
realis: 2021/09/21 08:03:54 retried this thrift call 5 time(s)
--- PASS: TestNonExistentEndpoint (5.21s)
=== RUN   TestBadCredentials
realis: 2021/09/21 08:03:54 [DEBUG]  Number of options applied to clientConfig:  3
realis: 2021/09/21 08:03:54 Scheduler URL:  http://192.168.33.7:8081
realis: 2021/09/21 08:03:54 gorealis clientConfig url: http://192.168.33.7:8081/api
realis: 2021/09/21 08:03:54 [DEBUG] CreateJob Thrift Payload: JobConfiguration({CronSchedule:<nil> CronCollisionPolicy:KILL_EXISTING TaskConfig:TaskConfig({IsService:true Priority:0 MaxTaskFailures:0 Owner:Identity({User:vagrant}) Production:<nil> Constraints:[] TaskLinks:map[] ContactEmail:<nil> ExecutorConfig:ExecutorConfig({Name:AuroraExecutor Data:{"task":{"processes":[{"name":"boostrap","cmdline":"echo bootsrapping","daemon":false,"ephemeral":false,"max_failures":1,"min_duration":5,"final":false},{"name":"hello_gorealis","cmdline":"while true; do echo hello world from gorealis; sleep 10; done","daemon":false,"ephemeral":false,"max_failures":1,"min_duration":5,"final":false}],"constraints":[{"order":["boostrap","hello_gorealis"]}],"resources":{"cpu":0.5,"disk":102600,"ram":65664}}}}) Metadata:[] Job:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_test}) Container:Container({Mesos:MesosContainer({Image:<nil> Volumes:[]}) Docker:<nil>}) Tier:<nil> Resources:[Resource({NumCpus:0xc000196738 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}) Resource({NumCpus:<nil> RamMb:0xc000196740 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}) Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc000196748 NamedPort:<nil> NumGpus:<nil>}) Resource({NumCpus:<nil> RamMb:<nil> DiskMb:<nil> NamedPort:0xc00018e3c0 NumGpus:<nil>})] MesosFetcherUris:[] PartitionPolicy:<nil> SlaPolicy:<nil>}) Owner:Identity({User:vagrant}) InstanceCount:2 Key:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_test})})
--- FAIL: TestBadCredentials (0.40s)
    realis_e2e_test.go:106:
        	Error Trace:	realis_e2e_test.go:106
        	Error:      	An error is expected but got nil.
        	Test:       	TestBadCredentials
=== RUN   TestThriftBinary
realis: 2021/09/21 08:03:55 Scheduler URL:  http://192.168.33.7:8081
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
--- PASS: TestThriftBinary (0.07s)
=== RUN   TestThriftJSON
realis: 2021/09/21 08:03:55 Scheduler URL:  http://192.168.33.7:8081
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
--- PASS: TestThriftJSON (0.01s)
=== RUN   TestNoopLogger
--- PASS: TestNoopLogger (0.01s)
=== RUN   TestLeaderFromZK
--- PASS: TestLeaderFromZK (0.02s)
=== RUN   TestInvalidAuroraURL
realis: 2021/09/21 08:03:55 Scheduler URL:  http://doesntexist.com:8081/apitest
realis: 2021/09/21 08:03:55 Scheduler URL:  test://doesntexist.com:8081
realis: 2021/09/21 08:03:55 Scheduler URL:  https://doesntexist.com:8081/testing/api
--- PASS: TestInvalidAuroraURL (0.00s)
=== RUN   TestValidAuroraURL
realis: 2021/09/21 08:03:55 Scheduler URL:  http://domain.com:8081/api
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://domain.com:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  https://domain.com:8081/api
realis: 2021/09/21 08:03:55 gorealis clientConfig url: https://domain.com:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  domain.com:8081
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://domain.com:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  domain.com
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://domain.com:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  192.168.33.7
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  192.168.33.7:8081
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
realis: 2021/09/21 08:03:55 Scheduler URL:  192.168.33.7:8081/api
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
--- PASS: TestValidAuroraURL (0.01s)
=== RUN   TestRealisClient_ReestablishConn
realis: 2021/09/21 08:03:55 Re-establishing Connection to Aurora
realis: 2021/09/21 08:03:55 Scheduler URL:  http://192.168.33.7:8081
realis: 2021/09/21 08:03:55 gorealis clientConfig url: http://192.168.33.7:8081/api
--- PASS: TestRealisClient_ReestablishConn (0.00s)
=== RUN   TestGetCACerts
--- PASS: TestGetCACerts (0.01s)
=== RUN   TestRealisClient_CreateJob_Thermos
realis: 2021/09/21 08:03:55 Terminal Response Code INVALID_REQUEST from Aurora, won't retry
GetJobs length: 1
=== RUN   TestRealisClient_CreateJob_Thermos/TestRealisClient_Snapshot
=== RUN   TestRealisClient_CreateJob_Thermos/TestRealisClient_PerformBackup
=== RUN   TestRealisClient_CreateJob_Thermos/TestRealisClient_KillJob_Thermos
--- FAIL: TestRealisClient_CreateJob_Thermos (14.36s)
    realis_e2e_test.go:239:
        	Error Trace:	realis_e2e_test.go:239
        	Error:      	Received unexpected error:
        	            	Job vagrant/prod/create_thermos_job_test already exists
        	            	github.com/aurora-scheduler/gorealis.(*Client).thriftCallWithRetries
        	            		/go/src/github.com/aurora-scheduler/gorealis/retry.go:233
        	            	github.com/aurora-scheduler/gorealis.(*Client).CreateJob
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:439
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_CreateJob_Thermos
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:238
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	            	error sending Create command to Aurora Scheduler
        	            	github.com/aurora-scheduler/gorealis.(*Client).CreateJob
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:444
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_CreateJob_Thermos
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:238
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	Test:       	TestRealisClient_CreateJob_Thermos
    --- PASS: TestRealisClient_CreateJob_Thermos/TestRealisClient_Snapshot (0.08s)
    --- PASS: TestRealisClient_CreateJob_Thermos/TestRealisClient_PerformBackup (0.04s)
    --- PASS: TestRealisClient_CreateJob_Thermos/TestRealisClient_KillJob_Thermos (3.05s)
=== RUN   TestRealisClient_CreateJob_ExecutorDoesNotExist
realis: 2021/09/21 08:04:09 Terminal Response Code INVALID_REQUEST from Aurora, won't retry
--- PASS: TestRealisClient_CreateJob_ExecutorDoesNotExist (0.01s)
=== RUN   TestRealisClient_GetPendingReason
--- PASS: TestRealisClient_GetPendingReason (0.06s)
=== RUN   TestRealisClient_CreateService_WithPulse_Thermos
Creating service
StartJobUpdateResult_({Key:JobUpdateKey({Job:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_pulse_test}) ID:f5b69684-9843-4064-b3a3-5481339843e9}) UpdateSummary:JobUpdateSummary({User:UNSECURE State:<nil> Key:JobUpdateKey({Job:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_pulse_test}) ID:f5b69684-9843-4064-b3a3-5481339843e9}) Metadata:[]})})
Update succeeded
--- PASS: TestRealisClient_CreateService_WithPulse_Thermos (102.16s)
=== RUN   TestRealisClient_CreateService
realis: 2021/09/21 08:06:37 job update status: ROLLED_FORWARD
--- PASS: TestRealisClient_CreateService (45.05s)
=== RUN   TestRealisClient_CreateService_ExecutorDoesNotExist
realis: 2021/09/21 08:06:37 Terminal Response Code INVALID_REQUEST from Aurora, won't retry
--- PASS: TestRealisClient_CreateService_ExecutorDoesNotExist (0.01s)
=== RUN   TestRealisClient_ScheduleCronJob_Thermos
=== RUN   TestRealisClient_ScheduleCronJob_Thermos/TestRealisClient_StartCronJob_Thermos
=== RUN   TestRealisClient_ScheduleCronJob_Thermos/TestRealisClient_DeschedulerCronJob_Thermos
--- PASS: TestRealisClient_ScheduleCronJob_Thermos (0.11s)
    --- PASS: TestRealisClient_ScheduleCronJob_Thermos/TestRealisClient_StartCronJob_Thermos (0.01s)
    --- PASS: TestRealisClient_ScheduleCronJob_Thermos/TestRealisClient_DeschedulerCronJob_Thermos (0.03s)
=== RUN   TestRealisClient_StartMaintenance
--- PASS: TestRealisClient_StartMaintenance (6.05s)
=== RUN   TestRealisClient_DrainHosts
=== RUN   TestRealisClient_DrainHosts/TestRealisClient_MonitorNontransitioned
=== RUN   TestRealisClient_DrainHosts/TestRealisClient_EndMaintenance
--- PASS: TestRealisClient_DrainHosts (7.05s)
    --- PASS: TestRealisClient_DrainHosts/TestRealisClient_MonitorNontransitioned (1.00s)
    --- PASS: TestRealisClient_DrainHosts/TestRealisClient_EndMaintenance (5.01s)
=== RUN   TestRealisClient_SLADrainHosts
--- PASS: TestRealisClient_SLADrainHosts (6.03s)
=== RUN   TestRealisClient_SessionThreadSafety
--- PASS: TestRealisClient_SessionThreadSafety (33.55s)
=== RUN   TestRealisClient_SetQuota
=== RUN   TestRealisClient_SetQuota/TestRealisClient_GetQuota
GetQuota Result<nil>--- PASS: TestRealisClient_SetQuota (0.05s)
    --- PASS: TestRealisClient_SetQuota/TestRealisClient_GetQuota (0.01s)
=== RUN   TestRealisClient_ForceImplicitTaskReconciliation
--- PASS: TestRealisClient_ForceImplicitTaskReconciliation (0.01s)
=== RUN   TestRealisClient_ForceExplicitTaskReconciliation
--- PASS: TestRealisClient_ForceExplicitTaskReconciliation (0.02s)
=== RUN   TestRealisClient_PartitionPolicy
realis: 2021/09/21 08:09:09 job update status: ROLLED_FORWARD
--- PASS: TestRealisClient_PartitionPolicy (100.04s)
=== RUN   TestRealisClient_UpdateStrategies
=== RUN   TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_Queue
realis: 2021/09/21 08:09:49 job update status: ROLLED_FORWARD
=== RUN   TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_Batch
realis: 2021/09/21 08:10:29 job update status: ROLLED_FORWARD
=== RUN   TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_VarBatch
realis: 2021/09/21 08:10:49 job update status: ROLLED_FORWARD
--- PASS: TestRealisClient_UpdateStrategies (100.14s)
    --- PASS: TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_Queue (40.05s)
    --- PASS: TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_Batch (40.04s)
    --- PASS: TestRealisClient_UpdateStrategies/TestRealisClient_UpdateStrategies_VarBatch (20.05s)
=== RUN   TestRealisClient_BatchAwareAutoPause
realis: 2021/09/21 08:11:25 Terminal Response Code INVALID_REQUEST from Aurora, won't retry
realis: 2021/09/21 08:11:25 Terminal Response Code INVALID_REQUEST from Aurora, won't retry
--- FAIL: TestRealisClient_BatchAwareAutoPause (35.13s)
    realis_e2e_test.go:818:
        	Error Trace:	realis_e2e_test.go:818
        	Error:      	Received unexpected error:
        	            	Cannot transition update from ROLLED_FORWARD to ABORTED
        	            	github.com/aurora-scheduler/gorealis.(*Client).thriftCallWithRetries
        	            		/go/src/github.com/aurora-scheduler/gorealis/retry.go:233
        	            	github.com/aurora-scheduler/gorealis.(*Client).AbortJobUpdate
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:579
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_BatchAwareAutoPause
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:818
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	            	error sending AbortJobUpdate command to Aurora Scheduler
        	            	github.com/aurora-scheduler/gorealis.(*Client).AbortJobUpdate
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:584
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_BatchAwareAutoPause
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:818
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	Test:       	TestRealisClient_BatchAwareAutoPause
    realis_e2e_test.go:821:
        	Error Trace:	realis_e2e_test.go:821
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : -1
        	Test:       	TestRealisClient_BatchAwareAutoPause
    realis_e2e_test.go:822:
        	Error Trace:	realis_e2e_test.go:822
        	Error:      	Received unexpected error:
        	            	Cannot transition update from ROLLED_FORWARD to null
        	            	github.com/aurora-scheduler/gorealis.(*Client).thriftCallWithRetries
        	            		/go/src/github.com/aurora-scheduler/gorealis/retry.go:233
        	            	github.com/aurora-scheduler/gorealis.(*Client).ResumeJobUpdate
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:631
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_BatchAwareAutoPause
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:822
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	            	error sending ResumeJobUpdate command to Aurora Scheduler
        	            	github.com/aurora-scheduler/gorealis.(*Client).ResumeJobUpdate
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis.go:636
        	            	github.com/aurora-scheduler/gorealis_test.TestRealisClient_BatchAwareAutoPause
        	            		/go/src/github.com/aurora-scheduler/gorealis/realis_e2e_test.go:822
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1357
        	Test:       	TestRealisClient_BatchAwareAutoPause
=== RUN   TestRealisClient_GetJobSummary
realis: 2021/09/21 08:12:55 job update status: ROLLED_FORWARD
--- FAIL: TestRealisClient_GetJobSummary (90.07s)
    realis_e2e_test.go:867:
        	Error Trace:	realis_e2e_test.go:867
        	Error:      	Not equal:
        	            	expected: 11
        	            	actual  : 1
        	Test:       	TestRealisClient_GetJobSummary
=== RUN   TestAuroraTask_Clone
--- PASS: TestAuroraTask_Clone (0.00s)
=== RUN   TestZKNoEndpoints
--- PASS: TestZKNoEndpoints (0.00s)
=== RUN   TestZKNoPath
--- PASS: TestZKNoPath (0.00s)
=== RUN   TestZKPathDoesntExist
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2021/09/21 A retryable error occurred during function call, backing off for 1.028865042s before retrying
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2021/09/21 A retryable error occurred during function call, backing off for 1.087593353s before retrying
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2021/09/21 A retryable error occurred during function call, backing off for 1.008335141s before retrying
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2021/09/21 A retryable error occurred during function call, backing off for 1.075875648s before retrying
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2021/09/21 retried this function call 5 time(s)
realis-debug: 2021/09/21 Failed to determine leader after 5 attempts
--- PASS: TestZKPathDoesntExist (4.21s)
=== RUN   TestZKBadPath
realis-debug: 2021/09/21 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2021/09/21 Failed to determine leader after 5 attempts
--- PASS: TestZKBadPath (0.00s)
FAIL
FAIL	github.com/aurora-scheduler/gorealis	549.903s
FAIL
```