### PR TITLE
Fix duplicate host issue for aurora scheduler, DTCPIOPS-5221

### DIFF
--- a/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
+++ b/src/main/java/io/github/aurora/scheduler/offers/HttpOfferSetImpl.java
@@ -18,7 +18,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Collectors;
 
@@ -332,22 +338,17 @@ public class HttpOfferSetImpl implements OfferSet {
       LOG.error("Unable to receive offers from {} due to {}", endpoint, response.error);
       throw new IOException(response.error);
     }
-    List<String> offerIDList = offerMap.keySet().stream()
-            .filter(offerId -> offerMap.get(offerId) != null && response.hosts
-                    .contains(offerMap.get(offerId).getOffer().getHostname()))
+    List<HostOffer> orderedOffers = offerMap.values().stream().filter(offer -> response.hosts.
+                    contains(offer.getOffer().getHostname()))
             .collect(Collectors.toList());
-    List<HostOffer> orderedOffers = offerIDList.stream()
-          .map(offerId -> offerMap.get(offerId))
-          .collect(Collectors.toList());
 
     List<String> mHosts = mOffers.stream().map(offer -> offer.getOffer().getHostname())
             .collect(Collectors.toList());
     List<String> extraOffers = response.hosts.stream().filter(host -> !mHosts.contains(host))
             .collect(Collectors.toList());
 
-    //offSetDiff is the absolute value of the different between Aurora offers and response offers
-    long offSetDiff = mOffers.size() - offerIDList.size() + extraOffers.size();
-    offSetDiff = Math.abs(offSetDiff);
+    //offSetDiff is the value of the different between Aurora offers and response offers
+    long offSetDiff = mOffers.size() - orderedOffers.size() + extraOffers.size();
     offerSetDiffList.add(offSetDiff);
     if (offSetDiff > 0) {
       LOG.warn("The number of different offers between the original and received offer sets is {}",

--- a/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
+++ b/src/test/java/io/github/aurora/scheduler/offers/HttpOfferSetImplTest.java
@@ -142,7 +142,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
 
     List<HostOffer> mOffers = ImmutableList.copyOf(httpOfferSet.values());
 
-    List<HostOffer> sortedOffers = httpOfferSet.processResponse(mOffers, responseStr);
+    List<HostOffer> sortedOffers = httpOfferSet.processResponse(mOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 3);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
@@ -153,7 +153,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     responseStr = "{\"error\": \"\", \"hosts\": [\""
             + HOST_A + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr);
+    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 2);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
@@ -165,7 +165,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_B + "\",\""
             + HOST_D + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr);
+    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 3);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
@@ -177,11 +177,18 @@ public class HttpOfferSetImplTest extends EasyMockTest {
         + HOST_A + "\",\""
         + HOST_D + "\",\""
         + HOST_C + "\"]}";
-    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr);
+    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 2);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
     assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(3), 2);
+
+    // Test with 1 bad offer
+    sortedOffers = httpOfferSet.processResponse(mOffers, responseStr, 1);
+    assertEquals(sortedOffers.size(), 2);
+    assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
+    assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(4), 3);
 
     responseStr = "{\"error\": \"Error\", \"hosts\": [\""
             + HOST_A + "\",\""
@@ -189,7 +196,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_C + "\"]}";
     boolean isException = false;
     try {
-      httpOfferSet.processResponse(mOffers, responseStr);
+      httpOfferSet.processResponse(mOffers, responseStr, 0);
     } catch (IOException ioe) {
       isException = true;
     }
@@ -198,7 +205,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     responseStr = "{\"error\": \"error\"}";
     isException = false;
     try {
-      httpOfferSet.processResponse(mOffers, responseStr);
+      httpOfferSet.processResponse(mOffers, responseStr, 0);
     } catch (IOException ioe) {
       isException = true;
     }
@@ -207,7 +214,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     responseStr = "{\"weird\": \"cannot decode this json string\"}";
     isException = false;
     try {
-      httpOfferSet.processResponse(mOffers, responseStr);
+      httpOfferSet.processResponse(mOffers, responseStr, 0);
     } catch (IOException ioe) {
       isException = true;
     }
@@ -224,23 +231,23 @@ public class HttpOfferSetImplTest extends EasyMockTest {
     assertEquals(mDuplicateHostOffers.size(), 4);
 
     sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers,
-            responseStr);
+            responseStr, 0);
     assertEquals(sortedOffers.size(), 4);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
     assertEquals(sortedOffers.get(2).getAttributes().getHost(), HOST_C);
     assertEquals(sortedOffers.get(3).getAttributes().getHost(), HOST_C);
-    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(4), 0);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(5), 0);
 
     // plugin returns less offers than Aurora has.
     responseStr = "{\"error\": \"\", \"hosts\": [\""
             + HOST_A + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr);
+    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 3);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_C);
-    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(5), 1);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(6), 1);
 
     // plugin returns more offers than Aurora has.
     responseStr = "{\"error\": \"\", \"hosts\": [\""
@@ -248,23 +255,30 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_B + "\",\""
             + HOST_D + "\",\""
             + HOST_C + "\"]}";
-    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr);
+    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 4);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
     assertEquals(sortedOffers.get(2).getAttributes().getHost(), HOST_C);
-    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(6), 1);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(7), 1);
 
     // plugin omits 1 offer & returns 1 extra offer
     responseStr = "{\"error\": \"\", \"hosts\": [\""
             + HOST_A + "\",\""
             + HOST_D + "\",\""
             + HOST_B + "\"]}";
-    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr);
+    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr, 0);
     assertEquals(sortedOffers.size(), 2);
     assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
     assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
-    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(7), 3);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(8), 3);
+
+    // Test with 1 bad offer
+    sortedOffers = duplicateHostsHttpOfferSet.processResponse(mDuplicateHostOffers, responseStr, 1);
+    assertEquals(sortedOffers.size(), 2);
+    assertEquals(sortedOffers.get(0).getAttributes().getHost(), HOST_A);
+    assertEquals(sortedOffers.get(1).getAttributes().getHost(), HOST_B);
+    assertEquals((long) HttpOfferSetImpl.offerSetDiffList.get(9), 4);
 
     responseStr = "{\"error\": \"Error\", \"hosts\": [\""
             + HOST_A + "\",\""
@@ -272,7 +286,7 @@ public class HttpOfferSetImplTest extends EasyMockTest {
             + HOST_C + "\"]}";
     isException = false;
     try {
-      duplicateHostsHttpOfferSet.processResponse(mOffers, responseStr);
+      duplicateHostsHttpOfferSet.processResponse(mOffers, responseStr, 0);
     } catch (IOException ioe) {
       isException = true;
     }


### PR DESCRIPTION
### Description:
This PR fixes duplicate host issue for aurora scheduler. 
Re-write the code to fix the issue, and still keep O(n) in processing response for efficiency to scale.



### Testing Done:
Set up a local cluster by cloning repo: https://github.com/lenhattan86/aurora-docker
Instructions in https://engineering.paypalcorp.com/confluence/pages/viewpage.action?spaceKey=GE&title=Aurora+scheduler+development+environment+and+test+setup, section Setup Aurora Scheduler testing environment. 
Change magicmatch/docker-compose.yml to have offers with 2 duplicate hostname to test the issue.
