### PR TITLE
Revert "Bump react-router-dom from 5.3.0 to 6.0.2 in /ui"

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
     "query-string": "^7.0.1",
     "react": "^16.14.0",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^6.0.2"
+    "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
     "ajv": "^8.6.2",


### PR DESCRIPTION
Reverts aurora-scheduler/scheduler#374 as this caused an UI issue
/scheduler does not show anything because the request not redirected to the right one.